### PR TITLE
Make player name matching more permissive

### DIFF
--- a/Friends.cs
+++ b/Friends.cs
@@ -249,6 +249,7 @@ namespace Oxide.Plugins
         IPlayer findPlayer(string nameOrId, out bool multipleMatches)
         {
             multipleMatches = false;
+            List<IPlayer> currentPlayers = covalence.Players.All.ToList();
 
             // First pass: Check for unique player id
             {
@@ -259,7 +260,7 @@ namespace Oxide.Plugins
 
             // Second pass: Check for exact name
             IPlayer found = null;
-            foreach (var player in covalence.Players.All)
+            foreach (var player in currentPlayers)
             {
                 if (player.Name == nameOrId)
                 {
@@ -274,10 +275,40 @@ namespace Oxide.Plugins
             if (found != null)
                 return found;
 
-            // Third pass: Check for partial name
-            foreach (var player in covalence.Players.All)
+            // Third pass: Check for exact name case insensitive
+            foreach (var player in currentPlayers)
+            {
+                if (player.Name.Equals(nameOrId, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (found != null)
+                    {
+                        multipleMatches = true;
+                        return found;
+                    }
+                    found = player;
+                }
+            }
+            if (found != null)
+                return found;
+
+            // Fourth pass: Check for partial name
+            foreach (var player in currentPlayers)
             {
                 if (player.Name.Contains(nameOrId))
+                {
+                    if (found != null)
+                    {
+                        multipleMatches = true;
+                        return found;
+                    }
+                    found = player;
+                }
+            }
+
+            // Fifth pass: Check for partial name case insensitive
+            foreach (var player in currentPlayers)
+            {
+                if (player.Name.IndexOf(nameOrId, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     if (found != null)
                     {


### PR DESCRIPTION
* Include case insensitive checks for full name and partial name matches.
* Cache the current player list in a local List before searching to prevent multiple enumerations of an IEnumerable.